### PR TITLE
Reorder manifest entries

### DIFF
--- a/custom_components/wattbox/const.py
+++ b/custom_components/wattbox/const.py
@@ -5,10 +5,10 @@ from typing import Dict, Final, List, TypedDict
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import (
-    ELECTRIC_POTENTIAL_VOLT,
+    UnitOfElectricPotential,
     PERCENTAGE,
-    POWER_WATT,
-    TIME_MINUTES,
+    UnitOfPower,
+    UnitOfTime,
 )
 
 # Base component constants
@@ -107,17 +107,17 @@ SENSOR_TYPES: Final[Dict[str, _SensorTypeDict]] = {
     "current_value": {"name": "Current", "unit": "A", "icon": "mdi:current-ac"},
     "est_run_time": {
         "name": "Estimated Run Time",
-        "unit": TIME_MINUTES,
+        "unit": UnitOfTime.MINUTES,
         "icon": "mdi:timer",
     },
     "power_value": {
         "name": "Power",
-        "unit": POWER_WATT,
+        "unit": UnitOfPower.WATT,
         "icon": "mdi:lightbulb-outline",
     },
     "voltage_value": {
         "name": "Voltage",
-        "unit": ELECTRIC_POTENTIAL_VOLT,
+        "unit": UnitOfElectricPotential.VOLT,
         "icon": "mdi:lightning-bolt-circle",
     },
 }

--- a/custom_components/wattbox/manifest.json
+++ b/custom_components/wattbox/manifest.json
@@ -1,15 +1,11 @@
 {
-    "domain": "wattbox",
-    "name": "WattBox",
-    "version": "0.8.0",
-    "issue_tracker": "https://github.com/eseglem/hass-wattbox/issues",
-    "documentation": "https://github.com/eseglem/hass-wattbox",
-    "dependencies": [],
-    "iot_class": "local_push",
-    "codeowners": [
-        "@eseglem"
-    ],
-    "requirements": [
-        "pywattbox>=0.4.0,<0.7.0"
-    ]
+  "domain": "wattbox",
+  "name": "WattBox",
+  "codeowners": ["@eseglem"],
+  "dependencies": [],
+  "documentation": "https://github.com/eseglem/hass-wattbox",
+  "iot_class": "local_push",
+  "issue_tracker": "https://github.com/eseglem/hass-wattbox/issues",
+  "requirements": ["pywattbox>=0.4.0,<0.7.0"],
+  "version": "0.8.0"
 }


### PR DESCRIPTION
Your [PR](https://github.com/eseglem/hass-wattbox/pull/26) had a [failing check](https://github.com/eseglem/hass-wattbox/actions/runs/12487831835/job/35589543172?pr=26#step:5:79), I think this fixes it.

```
Integration wattbox - /github/workspace/custom_components/wattbox:
Error: R] [MANIFEST] Manifest keys are not sorted correctly: domain, name, then alphabetical order

Error: Process completed with exit code 1.
```